### PR TITLE
feat: :sparkles: added ability to output exitcode in Terraform Plan task

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformTask/TerraformTaskV1/Strings/resources.resjson/en-US/resources.resjson
@@ -42,5 +42,6 @@
   "loc.input.help.backendGCPBucketName": "The name of the GCP storage bucket for storing the Terraform remote state file.",
   "loc.input.label.backendGCPPrefix": "Prefix of state file",
   "loc.input.help.backendGCPPrefix": "The relative path to the state file inside the GCP bucket. For example, if you give the input as 'terraform', then the state file, named default.tfstate, will be stored inside an object called terraform.",
-  "loc.messages.TerraformToolNotFound": "Failed to find terraform tool in paths"
+  "loc.messages.TerraformToolNotFound": "Failed to find terraform tool in paths",
+  "loc.messages.TerraformPlanFailed": "Terraform Plan failed with exit code: %s"
 }

--- a/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -119,7 +119,7 @@ export abstract class BaseTerraformCommandHandler {
             "plan",
             tasks.getInput("workingDirectory"),
             tasks.getInput(serviceName, true),
-            tasks.getInput("commandOptions")
+            `${tasks.getInput("commandOptions")} -detailed-exitcode`
         );
         
         let terraformTool;
@@ -203,7 +203,8 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async plan(): Promise<number> {
-        await this.onlyPlan();
+        let exitCode = await this.onlyPlan();
+        tasks.setVariable('changesPresent', (exitCode === 2).toString());
         this.setOutputVariableToPlanFilePath();
 
         return Promise.resolve(0);

--- a/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -126,7 +126,7 @@ export abstract class BaseTerraformCommandHandler {
         terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
         this.handleProvider(planCommand);
     
-        let result = terraformTool.exec(<IExecOptions> {
+        let result = await terraformTool.exec(<IExecOptions> {
             cwd: planCommand.workingDirectory,
             ignoreReturnCode: true
         });

--- a/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -126,9 +126,16 @@ export abstract class BaseTerraformCommandHandler {
         terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
         this.handleProvider(planCommand);
     
-        return terraformTool.exec(<IExecOptions> {
-            cwd: planCommand.workingDirectory
+        let result = terraformTool.exec(<IExecOptions> {
+            cwd: planCommand.workingDirectory,
+            ignoreReturnCode: true
         });
+        
+        if (result !== 0 && result !== 2) {
+            throw new Error(tasks.loc("TerraformPlanFailed", result));
+        }
+        
+        return result;
     }
 
     public setOutputVariableToPlanFilePath() {

--- a/Tasks/TerraformTask/TerraformTaskV1/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV1/task.json
@@ -264,6 +264,7 @@
         }
     ],
     "messages": {
-        "TerraformToolNotFound": "Failed to find terraform tool in paths"
+        "TerraformToolNotFound": "Failed to find terraform tool in paths",
+        "TerraformPlanFailed": "Terraform Plan failed with exit code: %s"
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV1/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV1/task.json
@@ -257,6 +257,10 @@
         {
             "name": "jsonOutputVariablesPath",
             "description": "The location of the JSON file which contains the output variables set by the user in the terraform config files.<br><br>Note: This variable will only be set if 'command' input is set to 'apply'."
+        },
+        {
+            "name": "changesPresent",
+            "description": "A boolean indicating if the terraform plan found any changes to apply."
         }
     ],
     "messages": {

--- a/Tasks/TerraformTask/TerraformTaskV1/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV1/task.loc.json
@@ -258,6 +258,10 @@
     {
       "name": "jsonOutputVariablesPath",
       "description": "The location of the JSON file which contains the output variables set by the user in the terraform config files.<br><br>Note: This variable will only be set if 'command' input is set to 'apply'."
+    },
+    {
+        "name": "changesPresent",
+        "description": "A boolean indicating if the terraform plan found any changes to apply."
     }
   ],
   "messages": {

--- a/Tasks/TerraformTask/TerraformTaskV1/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV1/task.loc.json
@@ -265,6 +265,7 @@
     }
   ],
   "messages": {
-    "TerraformToolNotFound": "ms-resource:loc.messages.TerraformToolNotFound"
+    "TerraformToolNotFound": "ms-resource:loc.messages.TerraformToolNotFound",
+    "TerraformPlanFailed": "ms-resource:loc.messages.TerraformPlanFailed"
   }
 }

--- a/Tasks/TerraformTask/TerraformTaskV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/TerraformTask/TerraformTaskV2/Strings/resources.resjson/en-US/resources.resjson
@@ -42,5 +42,6 @@
   "loc.input.help.backendGCPBucketName": "The name of the GCP storage bucket for storing the Terraform remote state file.",
   "loc.input.label.backendGCPPrefix": "Prefix of state file",
   "loc.input.help.backendGCPPrefix": "The relative path to the state file inside the GCP bucket. For example, if you give the input as 'terraform', then the state file, named default.tfstate, will be stored inside an object called terraform.",
-  "loc.messages.TerraformToolNotFound": "Failed to find terraform tool in paths"
+  "loc.messages.TerraformToolNotFound": "Failed to find terraform tool in paths",
+  "loc.messages.TerraformPlanFailed": "Terraform Plan failed with exit code: %s"
 }

--- a/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
@@ -127,7 +127,7 @@ export abstract class BaseTerraformCommandHandler {
         terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
         this.handleProvider(planCommand);
     
-        let result = terraformTool.exec(<IExecOptions> {
+        let result = await terraformTool.exec(<IExecOptions> {
             cwd: planCommand.workingDirectory,
             ignoreReturnCode: true
         });

--- a/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
@@ -120,7 +120,7 @@ export abstract class BaseTerraformCommandHandler {
             "plan",
             tasks.getInput("workingDirectory"),
             tasks.getInput(serviceName, true),
-            tasks.getInput("commandOptions")
+            `${tasks.getInput("commandOptions")} -detailed-exitcode`
         );
         
         let terraformTool;
@@ -203,7 +203,8 @@ export abstract class BaseTerraformCommandHandler {
     }
 
     public async plan(): Promise<number> {
-        await this.onlyPlan();
+        let exitCode = await this.onlyPlan();
+        tasks.setVariable('changesPresent', (exitCode === 2).toString());
         this.setOutputVariableToPlanFilePath();
 
         return Promise.resolve(0);

--- a/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
@@ -127,9 +127,16 @@ export abstract class BaseTerraformCommandHandler {
         terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
         this.handleProvider(planCommand);
     
-        return terraformTool.exec(<IExecOptions> {
-            cwd: planCommand.workingDirectory
+        let result = terraformTool.exec(<IExecOptions> {
+            cwd: planCommand.workingDirectory,
+            ignoreReturnCode: true
         });
+        
+        if (result !== 0 && result !== 2) {
+            throw new Error(tasks.loc("TerraformPlanFailed", result));
+        }
+        
+        return result;
     }
 
     public setOutputVariableToPlanFilePath() {

--- a/Tasks/TerraformTask/TerraformTaskV2/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV2/task.json
@@ -264,6 +264,7 @@
         }
     ],
     "messages": {
-        "TerraformToolNotFound": "Failed to find terraform tool in paths"
+        "TerraformToolNotFound": "Failed to find terraform tool in paths",
+        "TerraformPlanFailed": "Terraform Plan failed with exit code: %s"
     }
 }

--- a/Tasks/TerraformTask/TerraformTaskV2/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV2/task.json
@@ -257,6 +257,10 @@
         {
             "name": "jsonOutputVariablesPath",
             "description": "The location of the JSON file which contains the output variables set by the user in the terraform config files.<br><br>Note: This variable will only be set if 'command' input is set to 'apply'."
+        },
+        {
+            "name": "changesPresent",
+            "description": "A boolean indicating if the terraform plan found any changes to apply."
         }
     ],
     "messages": {

--- a/Tasks/TerraformTask/TerraformTaskV2/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV2/task.loc.json
@@ -258,6 +258,10 @@
     {
       "name": "jsonOutputVariablesPath",
       "description": "The location of the JSON file which contains the output variables set by the user in the terraform config files.<br><br>Note: This variable will only be set if 'command' input is set to 'apply'."
+    },
+    {
+        "name": "changesPresent",
+        "description": "A boolean indicating if the terraform plan found any changes to apply."
     }
   ],
   "messages": {

--- a/Tasks/TerraformTask/TerraformTaskV2/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV2/task.loc.json
@@ -265,6 +265,7 @@
     }
   ],
   "messages": {
-    "TerraformToolNotFound": "ms-resource:loc.messages.TerraformToolNotFound"
+    "TerraformToolNotFound": "ms-resource:loc.messages.TerraformToolNotFound",
+    "TerraformPlanFailed": "ms-resource:loc.messages.TerraformPlanFailed"
   }
 }


### PR DESCRIPTION
This feature allows the exitcode of Terraform Plan to be consumed within the pipeline after a run