### PR TITLE
feat: :art: changed changesPresent variable isOutput to true

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -213,7 +213,7 @@ export abstract class BaseTerraformCommandHandler {
 
     public async plan(): Promise<number> {
         let exitCode = await this.onlyPlan();
-        tasks.setVariable('changesPresent', (exitCode === 2).toString());
+        tasks.setVariable('changesPresent', (exitCode === 2).toString(), false, true);
         this.setOutputVariableToPlanFilePath();
 
         return Promise.resolve(0);

--- a/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
@@ -214,7 +214,7 @@ export abstract class BaseTerraformCommandHandler {
 
     public async plan(): Promise<number> {
         let exitCode = await this.onlyPlan();
-        tasks.setVariable('changesPresent', (exitCode === 2).toString());
+        tasks.setVariable('changesPresent', (exitCode === 2).toString(), false, true);
         this.setOutputVariableToPlanFilePath();
 
         return Promise.resolve(0);


### PR DESCRIPTION
This change will allow consumers of the task to do something like
```yaml
- job: Plan
  displayName: Terraform Plan
  steps:
  - task: TerraformTaskV2@2
    displayName: "Terraform: Plan"
    inputs:
      command: 'plan'
      . . .
- job: Approval
  displayName: Manual Approval
  dependsOn: Plan
  condition: and(succeeded(), eq(dependencies.Plan.outputs['changesPresent'], 'true'))
  pool: server
  steps:
  - task: ManualValidation@0
    timeoutInMinutes: 60
    inputs:
      instructions: "Please validate the Terraform Plan"
      onTimeout: 'reject'
- job: Apply
  displayName: Terraform Apply
  dependsOn: Approval
  condition: and(succeeded(), eq(dependencies.Plan.outputs['changesPresent'], 'true'))
  steps:
  - task: TerraformTaskV2@2
    displayName: "Terraform: Apply"
    inputs:
      command: 'apply'
      . . .
```