### PR TITLE
Fix descripion of jsonOutputVariablesPath

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV3/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV3/task.json
@@ -301,7 +301,7 @@
         },
         {
             "name": "jsonOutputVariablesPath",
-            "description": "The location of the JSON file which contains the output variables set by the user in the terraform config files.<br><br>Note: This variable will only be set if 'command' input is set to 'apply'."
+            "description": "The location of the JSON file which contains the output variables set by the user in the terraform config files.<br><br>Note: This variable will only be set if 'command' input is set to 'output'."
         },
         {
             "name": "changesPresent",


### PR DESCRIPTION
The description of the jsonOutputVariablesPath outputVariable says "This variable will only be set if 'command' input is set to 'apply'".

After reviewing the code, this is incorrect and should read "This variable will only be set if 'command' input is set to 'output'".