### PR TITLE
Remove CHMOD 777 to fix #128

### DIFF
--- a/Tasks/TerraformInstaller/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/src/terraform-installer.ts
@@ -69,11 +69,7 @@ export async function downloadTerraform(inputVersion: string): Promise<string> {
     if (!terraformPath) {
         throw new Error(tasks.loc("TerraformNotFoundInFolder", cachedToolPath));
     }
-
-    if (!isWindows) {
-        fs.chmodSync(terraformPath, "777");
-    }
-
+    
     tasks.setVariable('terraformLocation', terraformPath);
 
     return terraformPath;

--- a/Tasks/TerraformInstaller/task.json
+++ b/Tasks/TerraformInstaller/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": "0",
-        "Minor": "202",
+        "Minor": "217",
         "Patch": "0"
     },
     "instanceNameFormat": "Install Terraform $(terraformVersion)",


### PR DESCRIPTION
I'm not sure why it would be necessary to set full access to a subfolder within the agent tools directory. It seems like an attempt to mask a different problem?