### PR TITLE
Moves token security closest to the location where the token enters t…

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV4/src/azure-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/src/azure-terraform-command-handler.ts
@@ -37,7 +37,6 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
                 var workloadIdentityFederationCredentials = await this.getWorkloadIdentityFederationCredentials(backendServiceName);
                 this.backendConfig.set('client_id', workloadIdentityFederationCredentials.servicePrincipalId);
                 this.backendConfig.set('oidc_token', workloadIdentityFederationCredentials.idToken);
-                console.log('##vso[task.setsecret]' + workloadIdentityFederationCredentials.idToken);
                 this.backendConfig.set('use_oidc', 'true');
                 break;
             

--- a/Tasks/TerraformTask/TerraformTaskV4/src/id-token-generator.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/src/id-token-generator.ts
@@ -11,6 +11,8 @@ export interface ITokenGenerator {
 
 export class TokenGenerator implements ITokenGenerator {
     public async generate(connectedService : string): Promise<string> {
-        return await getFederatedToken(connectedService);
+        const token = await getFederatedToken(connectedService);
+        console.log('##vso[task.setsecret]' + token);
+        return token;
     }
 }


### PR DESCRIPTION
Moves the `setSecret` call closest to the place the token enters the scope of the task to prevent accidental logging of the token in the future.

This does mix concerns a little bit, but this prevents a change in the 4 functions in the call chain from accidentally surfacing the token in the future.

This could be refactored to a promise that can be passed to the token generator. 