### PR TITLE
Change GCP credential filename generation to be deterministic instead of random.

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/src/gcp-terraform-command-handler.ts
@@ -3,7 +3,7 @@ import {ToolRunner} from 'azure-pipelines-task-lib/toolrunner';
 import {TerraformAuthorizationCommandInitializer} from './terraform-commands';
 import {BaseTerraformCommandHandler} from './base-terraform-command-handler';
 import path = require('path');
-import * as uuidV4 from 'uuid/v4';
+import * as uuidV5 from 'uuid/v5';
 
 export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
     constructor() {
@@ -13,7 +13,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
 
     private getJsonKeyFilePath(serviceName: string) {
         // Get credentials for json file
-        const jsonKeyFilePath = path.resolve(`credentials-${uuidV4()}.json`);
+        const jsonKeyFilePath = path.resolve(`credentials-${uuidV5(serviceName, uuidV5.URL)}.json`);
 
         let clientEmail = tasks.getEndpointAuthorizationParameter(serviceName, "Issuer", false);
         let tokenUri = tasks.getEndpointAuthorizationParameter(serviceName, "Audience", false);

--- a/Tasks/TerraformTask/TerraformTaskV4/task.json
+++ b/Tasks/TerraformTask/TerraformTaskV4/task.json
@@ -14,7 +14,7 @@
     "demands": [],
     "version": {
         "Major": "4",
-        "Minor": "228",
+        "Minor": "236",
         "Patch": "0"
     },
     "instanceNameFormat": "Terraform : $(provider)",

--- a/Tasks/TerraformTask/TerraformTaskV4/task.loc.json
+++ b/Tasks/TerraformTask/TerraformTaskV4/task.loc.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": "4",
-    "Minor": "228",
+    "Minor": "236",
     "Patch": "0"
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
# This PR attempts to address issue #145. 

## Problem

The behavior of the Terraform Google provider changed after the release of 4.0.0, and this change is slightly incompatible with the way the `TerraformCommandHandlerGCP` class handles the generation of Google Cloud specific 'credentials' files used for authorizing Terraform to a Google Cloud project (akin to a Service Principle in Azure nomenclature). Specifically, the issue arises during the use of multi-stage pipelines.

## Analysis

Historically, when a Terraform plan was saved with the -out parameter, it also embedded a file path to the credential-files.json containing the authorization credentials to the Google project. However, if the credentials-file.json was available via environment variable, the order of precedence would favor environment variable over the embedded path in the plan file. So long as the credential file existed in the "GOOGLE_CREDENTIALS" environment variable, everything would work just fine because this task would generate a new credential file on every stage/job, and set the variable accordingly.

When v4.0.0.0 was published, this order of precedence changed. Now, instead favoring the environment variable "GOOGLE_CREDENTIALS" first, the provider favors the embedded file path first. The reason this becomes an issue in multi-stage pipelines is because of the use of uuid4() to generate the credentials file:

```
const jsonKeyFilePath = path.resolve(`credentials-${uuidV4()}.json`);
```

This results in a randomly named file saved to disk. The filename that was used to generate the plan in the first stage, no longer exists on the second/apply stage, since each stage is not guaranteed to be run on the same ephemeral Azure DevOps agent. This will manifest itself is a few possible error message including:

```
/opt/hostedtoolcache/terraform/1.6.6/x64/terraform apply -auto-approve /home/vsts/work/1/tfplan/main.tfplan
╷
│ Error: the string provided in credentials is neither valid json nor a valid file path
│ 
│ 
╵
##[error]Error: The process '/opt/hostedtoolcache/terraform/1.6.6/x64/terraform' failed with exit code 1
Finishing: Apply Terraform Plan
```

## Solution

### Approach

There were a few different proposed solutions to the issue, and I ended up going with the most straightforward change that had the least impact. My goals was to have the task generate a credential filename that was the _same_ for any given build/service connection, so that even between stages if the credential file was re-generated the embedded path in the plan file would remain valid.

My initial thought was to use some kind of MD5 or SHA-1 hashing, and hash a known value to generate the file name. After a quick analysis of the code though, I did not want to introduce any new dependencies as part of this change such as including NodeJS's 'crytpo' or other potentially bloated hashing NPM packages. Luckily, the functionality I was looking for was staring me right in the face: The already included UUID package.

Some quick history on UUID's:
- Version 1: The original, not very random, based on host machine hardware characteristics + datetime.
- Version 2: Similar to Version 1, minor tweaks, seldomly used.
- Version 3: Deterministic, based a 'namespace' and some string value, but uses MD5, outdated. Use V5 instead.
- Version 4: "Random" (probably the most used),
- Version 5: Same as V3 but uses SHA-1.

### The actual change

This PR updates the jsonKeyFilePath property to instead use `uuidV5()` instead of `uuidV4()` This results in a filename that is the deterministic based on the service connection name, and safe for writing to disk on any platform/OS:

```
const jsonKeyFilePath = path.resolve(`credentials-${uuidV5(serviceName, uuidV5.URL)}.json`);
```

In this case, the value we are hashing is the serviceName variable. This could just have easily been build ID or anything else that remains constant between stages of a pipeline run that the task has access to.

The namespace (yet another UUID) I chose for uuidV5() is `uuidV5.URL`, which is a published, known, constant generally used to represent URLs (`6ba7b811-9dad-11d1-80b4-00c04fd430c8`). There are four preexisting namespace hard-coded GUIDs [defined by RFC 4122](https://www.rfc-editor.org/rfc/rfc4122), in this case it doesn't matter what the namespace is, so long as it is consistent between stages, so I elected to use somewhat friendly looking `uuidV5.URL` rather than make up some arbitrary UUID value in-line:

```
const jsonKeyFilePath = path.resolve(`credentials-${uuidV5(serviceName, "12345678-1234-1234-1234-123456789012")}.json`);
```

Gross, right? But I digress. I made sure to test this all thoroughly with the version of UUID in _actual use_ by the package lock file: [3.4.0](https://github.com/uuidjs/uuid/tree/v3.4.0).

## Testing

This took some time and effort to test. My testing methodology consisted of:
- Verifying all the unit tests in the projects run (by following the CONTRIBUTING.md guide)
- Publishing a self/dev version of the Task to the private marketplace (again per the guide)
- Creating a new DevOps organization
- Installing the self/dev VSTX package into the organization
- Creating a new AzDo Project, repository, pipeline
- Creating a new multi-stage deployment YAML file with some Hello World! Terraform that would publish and download a plan file
- Creating a new Google Cloud project, state file bucket, service account, and service account key
- Adding the service account to the AzDo organization as a GCP Terraform service account
- Kicking off the pipeline, observe success.
- Remove self/dev VSTX, install marketplace Terraform tasks
- Re-run the pipeline from the same branch/hash/commit, observe failure.

- Re-run the pipeline steps above on both:
  - Self-hosted agents running in Azure VM Scale-Sets
  - Microsoft-hosted agents ('ubuntu-latest')

## Evidence

First, using the current marketplace version:
![failing_task_extension](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/58fd5c49-66a2-42b8-b609-38c0fae8d689)


Pipeline runs, fist is marketplace task, second is task from my branch/PR:
![pipeline_runs](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/aa9a9d6b-507c-40a2-8057-12f6e111e337)

In the current/failing task, notice the UUID is different for the generated credential files between the plan and apply stages.
Plan:
![failing_task_plan](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/6a16b90f-a337-4fb4-bad8-92b87cf6a197)

Apply:
![failing_task_apply](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/771d76a5-868a-47a4-a5b9-52136ad382bd)

![failing_task_apply_error](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/ab749334-e6cc-459d-984b-360c3b429156)



Now, using the VSTX from this PR:
![success_task_extension](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/6f84ac06-8530-41d6-97b8-ab4c6e4f8c1d)


Using the Terraform task from this PR, we can observe that UUID for the credentials files are now consistent between stages:
Plan:
![success_task_plan](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/fc69a7f5-c34d-4383-98b7-0907418bd176)

Apply:
![success_task_apply](https://github.com/microsoft/azure-pipelines-terraform/assets/106233/58145009-ca7d-41d4-b420-df89a0fcc727)

---

Thank you for your consideration.
