### PR TITLE
Update the default version used when Hashicorp API fails

### DIFF
--- a/Tasks/TerraformInstaller/TerraformInstallerV0/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV0/src/terraform-installer.ts
@@ -24,7 +24,7 @@ export async function downloadTerraform(inputVersion: string): Promise<string> {
             .catch((exception: any) => {
                 console.warn(tasks.loc("TerraformVersionNotFound"));
 
-                latestVersion = '1.1.6';
+                latestVersion = '1.9.8';
             })
         }
         else
@@ -39,7 +39,7 @@ export async function downloadTerraform(inputVersion: string): Promise<string> {
             })
             .catch((exception: any) => {
                 console.warn(tasks.loc("TerraformVersionNotFound"));
-                latestVersion = '1.1.6';
+                latestVersion = '1.9.8';
             })
         }
     }

--- a/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
+++ b/Tasks/TerraformInstaller/TerraformInstallerV1/src/terraform-installer.ts
@@ -24,7 +24,7 @@ export async function downloadTerraform(inputVersion: string): Promise<string> {
             .catch((exception: any) => {
                 console.warn(tasks.loc("TerraformVersionNotFound"));
 
-                latestVersion = '1.1.6';
+                latestVersion = '1.9.8';
             })
         }
         else
@@ -39,7 +39,7 @@ export async function downloadTerraform(inputVersion: string): Promise<string> {
             })
             .catch((exception: any) => {
                 console.warn(tasks.loc("TerraformVersionNotFound"));
-                latestVersion = '1.1.6';
+                latestVersion = '1.9.8';
             })
         }
     }


### PR DESCRIPTION
To minimize the issue when the Hashicorp API is failing (#216) I propose to update the version to the most recent.