### PR TITLE
`-json` must come before arguments

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV4/src/base-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/src/base-terraform-command-handler.ts
@@ -127,7 +127,7 @@ export abstract class BaseTerraformCommandHandler {
     }
     public async output(): Promise<number> {
         let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
-        let commandOptions = tasks.getInput("commandOptions") != null ? `${tasks.getInput("commandOptions")} -json`:`-json`
+        let commandOptions = tasks.getInput("commandOptions") != null ? `-json ${tasks.getInput("commandOptions")}`:`-json`
         
         let outputCommand = new TerraformAuthorizationCommandInitializer(
             "output",


### PR DESCRIPTION
in terraform output command

❯ terraform output -help
Usage: terraform [global options] output [options] [NAME]


Fix #269
