### PR TITLE
Update example of TerraformTask to also check for success to not get stuck

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV4/README.md
+++ b/Tasks/TerraformTask/TerraformTaskV4/README.md
@@ -128,7 +128,7 @@ Below is a basic example usage of a few commands within the TerraformTaskV4 task
 # Only runs if the 'terraformPlan' task has detected changes the in state. 
 - task: TerraformTaskV4@4
   displayName: Apply Terraform Plan
-  condition: eq(variables['terraformPlan.changesPresent'], 'true')
+  condition: and(succeeded(), eq(variables['terraformPlan.changesPresent'], 'true'))
   inputs:
     provider: 'azurerm'
     command: 'apply'


### PR DESCRIPTION
Closes #272 

As suggested in the issue, this is to avoid causing an issue that can make a task not get cancelled when a user manually cancels an Azure pipeline.

My hope is that this change would help other people not spend a long time debugging why a pipeline continues to run, after pressing the "cancel" button in the Azure pipeline, when the task had a condition statement.