### PR TITLE
Omit registry URLs from the Terraform plan lockfile

### DIFF
--- a/views/terraform-plan/.npmrc
+++ b/views/terraform-plan/.npmrc
@@ -1,1 +1,2 @@
 registry=https://packagefeedproxy.microsoft.io/npm/
+omit-lockfile-registry-resolved=true

--- a/views/terraform-plan/package-lock.json
+++ b/views/terraform-plan/package-lock.json
@@ -38,7 +38,6 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha1-AGKcNaaI4FqIsc2mhPudXnPwAKE=",
       "dev": true,
       "license": "MIT",
@@ -51,7 +50,6 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha1-ZTT9WTOlO6fL86F2FeJzoNEnP/k=",
       "dev": true,
       "license": "MIT",
@@ -62,7 +60,6 @@
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
       "integrity": "sha1-RLXONIXpUjWsoG5ijuqqPIFrxMw=",
       "dev": true,
       "license": "MIT",
@@ -72,7 +69,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
       "dev": true,
       "license": "ISC",
@@ -90,7 +86,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "dev": true,
       "license": "MIT",
@@ -101,7 +96,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
@@ -111,7 +105,6 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha1-shg1y9Nttla4V8KtAuvUE8wTqbo=",
       "dev": true,
       "license": "MIT",
@@ -122,14 +115,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "dev": true,
       "license": "MIT",
@@ -140,7 +131,6 @@
     },
     "node_modules/@jsonjoy.com/base64": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
       "integrity": "sha1-z46p3LhJuByV8U/AqqFRxrVNJXg=",
       "dev": true,
       "license": "Apache-2.0",
@@ -157,7 +147,6 @@
     },
     "node_modules/@jsonjoy.com/buffers": {
       "version": "17.67.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
       "integrity": "sha1-XFjbze6ogkzilr0c/OAGwusWez0=",
       "dev": true,
       "license": "Apache-2.0",
@@ -174,7 +163,6 @@
     },
     "node_modules/@jsonjoy.com/codegen": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
       "integrity": "sha1-XCP3lsR2dfFm0juUjNuIkYS5Mgc=",
       "dev": true,
       "license": "Apache-2.0",
@@ -191,7 +179,6 @@
     },
     "node_modules/@jsonjoy.com/fs-core": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
       "integrity": "sha1-Ff7Sgq8qjvvRozWoOuG9NQf6Ajc=",
       "dev": true,
       "license": "Apache-2.0",
@@ -213,7 +200,6 @@
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
       "integrity": "sha1-AJ68kDlmItN9+YRpH76LrVH97eo=",
       "dev": true,
       "license": "Apache-2.0",
@@ -236,7 +222,6 @@
     },
     "node_modules/@jsonjoy.com/fs-node": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
       "integrity": "sha1-DKcW5sPvXtiIf71LRVcJT5kpPRk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -262,7 +247,6 @@
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
       "integrity": "sha1-PE7ph34S126rhhFmO+oSfQ4mH8U=",
       "dev": true,
       "license": "Apache-2.0",
@@ -279,7 +263,6 @@
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
       "integrity": "sha1-0Nq38Af54B3NHmLS4n7A/dASZVQ=",
       "dev": true,
       "license": "Apache-2.0",
@@ -301,7 +284,6 @@
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
       "integrity": "sha1-JfpwwcEZhu73XB5sUsrqn+Lml3g=",
       "dev": true,
       "license": "Apache-2.0",
@@ -322,7 +304,6 @@
     },
     "node_modules/@jsonjoy.com/fs-print": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
       "integrity": "sha1-vYMPkHZBVfsTEyBiQkjTPnINYTA=",
       "dev": true,
       "license": "Apache-2.0",
@@ -343,7 +324,6 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
       "integrity": "sha1-Zy2Cy2Xa0Yw6H899IiVNA35qeUo=",
       "dev": true,
       "license": "Apache-2.0",
@@ -366,7 +346,6 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
       "version": "17.67.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
       "integrity": "sha1-fu2jy0ETjXepBAj9LkKyq6EFdtc=",
       "dev": true,
       "license": "Apache-2.0",
@@ -383,7 +362,6 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
       "version": "17.67.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
       "integrity": "sha1-NjX9h2nXfhm3XcVXS8l1YBmy5ZE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -400,7 +378,6 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
       "version": "17.67.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
       "integrity": "sha1-jdj/Zd2ZnF1NJt9GxjkVx73sCTo=",
       "dev": true,
       "license": "Apache-2.0",
@@ -427,7 +404,6 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
       "version": "17.67.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
       "integrity": "sha1-dEOVc9wEbgyaOlUvuUs5G8dTE7g=",
       "dev": true,
       "license": "Apache-2.0",
@@ -447,7 +423,6 @@
     },
     "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
       "version": "17.67.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/util/-/util-17.67.0.tgz",
       "integrity": "sha1-fEKI/DgIIz5Vx2EBAee7RZDN3T8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -468,7 +443,6 @@
     },
     "node_modules/@jsonjoy.com/json-pack": {
       "version": "1.21.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
       "integrity": "sha1-k/jdV/46OpITKzPR6xgtzZ52Kfo=",
       "dev": true,
       "license": "Apache-2.0",
@@ -495,7 +469,6 @@
     },
     "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
       "integrity": "sha1-jZnH9n6vck00KN/ZgmxkVSZqXIM=",
       "dev": true,
       "license": "Apache-2.0",
@@ -512,7 +485,6 @@
     },
     "node_modules/@jsonjoy.com/json-pointer": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
       "integrity": "sha1-BJy1MKwk6Ey6CFkMXja0McSENAg=",
       "dev": true,
       "license": "Apache-2.0",
@@ -533,7 +505,6 @@
     },
     "node_modules/@jsonjoy.com/util": {
       "version": "1.9.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/util/-/util-1.9.0.tgz",
       "integrity": "sha1-fulVhq7Qp2a3Rs2Ng2PjNsPEfEY=",
       "dev": true,
       "license": "Apache-2.0",
@@ -554,7 +525,6 @@
     },
     "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
       "integrity": "sha1-jZnH9n6vck00KN/ZgmxkVSZqXIM=",
       "dev": true,
       "license": "Apache-2.0",
@@ -571,14 +541,12 @@
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha1-T8VsFcWAua233DwzOhNOVAtEv7E=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha1-RYFKoynzDk/guklCb0nfzN0GZCY=",
       "dev": true,
       "license": "MIT",
@@ -591,7 +559,6 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher/-/watcher-2.6.0.tgz",
       "integrity": "sha1-mWYfYiAHC3anZqumt+MToIehvk8=",
       "dev": true,
       "hasInstallScript": true,
@@ -627,7 +594,6 @@
     },
     "node_modules/@parcel/watcher-android-arm64": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
       "integrity": "sha1-maqjIj1DgHyTQK9DnK1+m20mraY=",
       "cpu": [
         "arm64"
@@ -648,7 +614,6 @@
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
       "integrity": "sha1-AkSW5Ya0dE8JzlMrvon+OO8Cpk4=",
       "cpu": [
         "arm64"
@@ -669,7 +634,6 @@
     },
     "node_modules/@parcel/watcher-darwin-x64": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
       "integrity": "sha1-pGId8TWak9OaMy2bq1/wkBagYI8=",
       "cpu": [
         "x64"
@@ -690,7 +654,6 @@
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
       "integrity": "sha1-f1Ze0aWzpeYE5qR5kSFRgmXWKj0=",
       "cpu": [
         "x64"
@@ -711,7 +674,6 @@
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
       "integrity": "sha1-rX04JeZ7gZmRZdpCWTAiBFq8CIk=",
       "cpu": [
         "arm"
@@ -735,7 +697,6 @@
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
       "integrity": "sha1-/n0czLLEgyFcCQ6TjPXPQE0vmow=",
       "cpu": [
         "arm"
@@ -759,7 +720,6 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
       "integrity": "sha1-fiOdy0ZGxMefAGpxMaSCOCSVMNo=",
       "cpu": [
         "arm64"
@@ -783,7 +743,6 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
       "integrity": "sha1-xYuNnG2NgVlL4A3YOqt0HBqvfg4=",
       "cpu": [
         "arm64"
@@ -807,7 +766,6 @@
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
       "integrity": "sha1-UYT6mncEeNhuVodfTuFjoKvch5E=",
       "cpu": [
         "x64"
@@ -831,7 +789,6 @@
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
       "integrity": "sha1-LRxVqnJGy8dnDiYSBYqKVCyc8kY=",
       "cpu": [
         "x64"
@@ -855,7 +812,6 @@
     },
     "node_modules/@parcel/watcher-win32-arm64": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
       "integrity": "sha1-FeCUMgQP7p4iE6qcEO1YkBJSbe8=",
       "cpu": [
         "arm64"
@@ -876,7 +832,6 @@
     },
     "node_modules/@parcel/watcher-win32-x64": {
       "version": "2.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
       "integrity": "sha1-m+4ZmipKzNVXtFGsLBx5PzBa4BI=",
       "cpu": [
         "x64"
@@ -897,7 +852,6 @@
     },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
       "integrity": "sha1-tIqDiTGSKPkp6azYzujabIWHON4=",
       "dev": true,
       "license": "MIT",
@@ -911,14 +865,12 @@
     },
     "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-csr": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
       "integrity": "sha1-ybtd7C6v+CSnBegqSljUXm0sNdA=",
       "dev": true,
       "license": "MIT",
@@ -931,14 +883,12 @@
     },
     "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-ecc": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
       "integrity": "sha1-1RqysH7KmODPSS0FHpi70KBxMFo=",
       "dev": true,
       "license": "MIT",
@@ -951,14 +901,12 @@
     },
     "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-pfx": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
       "integrity": "sha1-jhibZFXiv55fkhuxUOqG1+fRh10=",
       "dev": true,
       "license": "MIT",
@@ -973,14 +921,12 @@
     },
     "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-pkcs8": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
       "integrity": "sha1-pGz4hXubBjiWr6QdK4sqpqB6cKI=",
       "dev": true,
       "license": "MIT",
@@ -993,14 +939,12 @@
     },
     "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-pkcs9": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
       "integrity": "sha1-bWJpevC71PMP3w0jtAGPPwliDeM=",
       "dev": true,
       "license": "MIT",
@@ -1017,14 +961,12 @@
     },
     "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-rsa": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
       "integrity": "sha1-nZjQ/EL+xQEZ0ogbipkl022q6nM=",
       "dev": true,
       "license": "MIT",
@@ -1037,14 +979,12 @@
     },
     "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
       "integrity": "sha1-aWmfhCWbIWFgfKv8NOUSpAI9vvk=",
       "dev": true,
       "license": "MIT",
@@ -1056,14 +996,12 @@
     },
     "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-x509": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
       "integrity": "sha1-mVip7zXeyEJqq614/+h5jjGLBuI=",
       "dev": true,
       "license": "MIT",
@@ -1076,7 +1014,6 @@
     },
     "node_modules/@peculiar/asn1-x509-attr": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
       "integrity": "sha1-vRaOP16Lwj5Wsal4kfny+39zAgQ=",
       "dev": true,
       "license": "MIT",
@@ -1089,21 +1026,18 @@
     },
     "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/utils": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/utils/-/utils-2.0.3.tgz",
       "integrity": "sha1-onykxLc2UuEQ8Zp9FtZk9FilUo4=",
       "dev": true,
       "license": "MIT",
@@ -1113,14 +1047,12 @@
     },
     "node_modules/@peculiar/utils/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@peculiar/x509": {
       "version": "1.14.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/x509/-/x509-1.14.3.tgz",
       "integrity": "sha1-LETCuJR0NGr+w4oMKAPsT7jOlZ4=",
       "dev": true,
       "license": "MIT",
@@ -1143,14 +1075,12 @@
     },
     "node_modules/@peculiar/x509/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
       "dev": true,
       "license": "MIT",
@@ -1161,35 +1091,30 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha1-vlfOrB5GkrQb6d5r6MMqEGY226Q=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha1-7j3vHyfZ7WbaxuRqKVz/sBUuBY0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha1-5DhjFihPALmENb9A9y91oJ2r9sE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha1-C5LcwMwcgfbzBqOB8o4xsaVlNuk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha1-GFm+u4/X2smRikXVTBlxq4ta9HQ=",
       "dev": true,
       "license": "MIT",
@@ -1200,7 +1125,6 @@
     },
     "node_modules/@types/bonjour": {
       "version": "3.5.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/bonjour/-/bonjour-3.5.13.tgz",
       "integrity": "sha1-rfkM4aEF6B3R+cYf3Fr9ob+5KVY=",
       "dev": true,
       "license": "MIT",
@@ -1210,7 +1134,6 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha1-W6fzvE+73q/43e2VLl/yzFP42Fg=",
       "dev": true,
       "license": "MIT",
@@ -1220,7 +1143,6 @@
     },
     "node_modules/@types/connect-history-api-fallback": {
       "version": "1.5.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
       "integrity": "sha1-fecWRaEDBWtIrDzgezUguBnB1bM=",
       "dev": true,
       "license": "MIT",
@@ -1231,14 +1153,12 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha1-LXJLLJkNy4yERAY/NYCpA/bVAMw=",
       "dev": true,
       "license": "MIT",
@@ -1250,7 +1170,6 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "5.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
       "integrity": "sha1-nTTIjAye5iuabk2firjX4paI5rQ=",
       "dev": true,
       "license": "MIT",
@@ -1263,35 +1182,30 @@
     },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
       "integrity": "sha1-T8M6AMHQwWmHsaIM+S0gYUxVrDU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha1-W3SasrFroRNCP+saZKldzTA5hHI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mocha/-/mocha-10.0.10.tgz",
       "integrity": "sha1-kfYpBejSPL1mIlMS8jlFSiO+v6A=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha1-Wkh1qGL9qP3Ffej6pXm7gey6FoU=",
       "dev": true,
       "license": "MIT",
@@ -1301,28 +1215,24 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha1-5uWobWAr6spxzlFj+t9fldcJMcc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.15.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha1-hgaIQnLGPw25aYa9NUhlDYqTiL8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha1-UK5DU+qt3AQEQnmBL1LIxlhX28s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "16.14.70",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react/-/react-16.14.70.tgz",
       "integrity": "sha1-yXtxemJj4Y5UbFSzuHBILYZ8apM=",
       "dev": true,
       "license": "MIT",
@@ -1334,7 +1244,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "16.9.25",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/react-dom/-/react-dom-16.9.25.tgz",
       "integrity": "sha1-/GRAqq49LTqhD2r+t/GwxKVdXjE=",
       "dev": true,
       "license": "MIT",
@@ -1344,14 +1253,12 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha1-zlrOBM/qvn74fACR5QdS42cH3v8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha1-anhORVQ8GMd0wEm/9tPbrwRcnHQ=",
       "dev": true,
       "license": "MIT",
@@ -1361,7 +1268,6 @@
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/serve-index/-/serve-index-1.9.4.tgz",
       "integrity": "sha1-5q4T1QU8sG7TY5IRC0+aSaxOyJg=",
       "dev": true,
       "license": "MIT",
@@ -1371,7 +1277,6 @@
     },
     "node_modules/@types/serve-static": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha1-1KRHUD6tDRZxEy0atr1YuAXY3mo=",
       "dev": true,
       "license": "MIT",
@@ -1382,14 +1287,12 @@
     },
     "node_modules/@types/url-parse": {
       "version": "1.4.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/url-parse/-/url-parse-1.4.11.tgz",
       "integrity": "sha1-Afj6p7i/1Djl9e+4M3p0UToVYCs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha1-SEZOS/Ld/RfbE9hFRn9gcP/qSqk=",
       "dev": true,
       "license": "MIT",
@@ -1399,7 +1302,6 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha1-qfagfysDyVyNOMRTah/ftSH/VbY=",
       "dev": true,
       "license": "MIT",
@@ -1410,28 +1312,24 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha1-/Moe7dscxOe27tT8eVbWgTshufs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha1-4KFhUiSLw42u523X4h8Vxe86sec=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha1-giqbxgMWZTH31d+E5ntb+ZtyuWs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha1-29kyVI5xGfS4p4d/1ajSDmNJCy0=",
       "dev": true,
       "license": "MIT",
@@ -1443,14 +1341,12 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha1-5VYQh1j0SKroTIUOWTzhig6zHgs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha1-lindqcRDDqtUtZEFPW3G87oFA0g=",
       "dev": true,
       "license": "MIT",
@@ -1463,7 +1359,6 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha1-HF6qzh1gatosf9cEXqk1bFnuDbo=",
       "dev": true,
       "license": "MIT",
@@ -1473,7 +1368,6 @@
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha1-V8XD3rAQXQLOJfo/109OvJ/Qu7A=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1483,14 +1377,12 @@
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha1-kXog6T9xrVYClmwtaFrgxsIfYPE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha1-rGaJ9QIhm1kZjd7ELc1JaxAE1Zc=",
       "dev": true,
       "license": "MIT",
@@ -1507,7 +1399,6 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha1-mR5/DAkMsLtiu6yIIHbj0hnalXA=",
       "dev": true,
       "license": "MIT",
@@ -1521,7 +1412,6 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha1-5vce18yuRngcIGAX08FMUO+oEGs=",
       "dev": true,
       "license": "MIT",
@@ -1534,7 +1424,6 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha1-s+E/GJNgXKeLUsaOVM9qhl+Qufs=",
       "dev": true,
       "license": "MIT",
@@ -1549,7 +1438,6 @@
     },
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha1-O7PpY4qK5f2vlhDnoGtNn5qm/gc=",
       "dev": true,
       "license": "MIT",
@@ -1560,21 +1448,18 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
       "dev": true,
       "license": "MIT",
@@ -1588,7 +1473,6 @@
     },
     "node_modules/accepts/node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
       "dev": true,
       "license": "MIT",
@@ -1598,7 +1482,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -1611,7 +1494,6 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-walk/-/acorn-walk-8.3.5.tgz",
       "integrity": "sha1-imuMqPxbNGha8V2rtEEYZjwpZJY=",
       "dev": true,
       "license": "MIT",
@@ -1624,7 +1506,6 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "dev": true,
       "license": "MIT",
@@ -1641,7 +1522,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha1-bmaUAGWet0lzu/LjMycYCgmWtSA=",
       "dev": true,
       "license": "MIT",
@@ -1659,7 +1539,6 @@
     },
     "node_modules/ajv-keywords": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha1-adTThaRzPNvqtElkoRcKiPh/DhY=",
       "dev": true,
       "license": "MIT",
@@ -1672,7 +1551,6 @@
     },
     "node_modules/ansi_up": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi_up/-/ansi_up-5.2.1.tgz",
       "integrity": "sha1-lDcILHrUl1wV7FfTCmtV2ilb7jY=",
       "license": "MIT",
       "engines": {
@@ -1681,7 +1559,6 @@
     },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
       "integrity": "sha1-afvE1sy+OD+XNpNK40w/gpDxv0E=",
       "dev": true,
       "engines": [
@@ -1694,7 +1571,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
@@ -1707,7 +1583,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "license": "MIT",
@@ -1723,21 +1598,18 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/arg/-/arg-4.1.3.tgz",
       "integrity": "sha1-Jp/HrVuOQstjyJbVZmAXJhwUQIk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha1-OE0So3KVrsN2mrAirTI6GKUcz4s=",
       "license": "MIT",
       "dependencies": {
@@ -1753,7 +1625,6 @@
     },
     "node_modules/array.prototype.find": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "license": "MIT",
       "dependencies": {
@@ -1763,7 +1634,6 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha1-nXYNhNvdBtDL+SyISWFaGnqzGDw=",
       "license": "MIT",
       "dependencies": {
@@ -1784,7 +1654,6 @@
     },
     "node_modules/asn1js": {
       "version": "3.0.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/asn1js/-/asn1js-3.0.10.tgz",
       "integrity": "sha1-3ybIdMiotBymBe/qR7KtB1UQE90=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1799,14 +1668,12 @@
     },
     "node_modules/asn1js/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha1-UJyfymDq+FA0xoKYOBiOTkyP+ys=",
       "license": "MIT",
       "engines": {
@@ -1815,7 +1682,6 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=",
       "license": "MIT",
       "dependencies": {
@@ -1830,7 +1696,6 @@
     },
     "node_modules/azure-devops-extension-api": {
       "version": "1.158.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/azure-devops-extension-api/-/azure-devops-extension-api-1.158.0.tgz",
       "integrity": "sha1-0pncA0FZE4pA/DUJ96FpIvC97r8=",
       "license": "MIT",
       "dependencies": {
@@ -1840,7 +1705,6 @@
     },
     "node_modules/azure-devops-extension-sdk": {
       "version": "2.0.11",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/azure-devops-extension-sdk/-/azure-devops-extension-sdk-2.0.11.tgz",
       "integrity": "sha1-A/BvqujbwYU+TyMC5GWmqr68yoo=",
       "license": "MIT",
       "dependencies": {
@@ -1850,7 +1714,6 @@
     },
     "node_modules/azure-devops-ui": {
       "version": "2.277.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/azure-devops-ui/-/azure-devops-ui-2.277.0.tgz",
       "integrity": "sha1-vjA1vXhS30FaUa8jUwYrJ0459xc=",
       "license": "MIT",
       "dependencies": {
@@ -1868,14 +1731,12 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.13",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
       "integrity": "sha1-ZgBzEDwb7pPlTfVfEXt1KK32rxk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1888,14 +1749,12 @@
     },
     "node_modules/batch": {
       "version": "0.6.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha1-bYZi9NjDNgKLismqJCUbDKZLpDc=",
       "dev": true,
       "license": "MIT",
@@ -1920,7 +1779,6 @@
     },
     "node_modules/body-parser/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
       "dev": true,
       "license": "MIT",
@@ -1934,7 +1792,6 @@
     },
     "node_modules/bonjour-service": {
       "version": "1.4.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bonjour-service/-/bonjour-service-1.4.4.tgz",
       "integrity": "sha1-j/W4X6BkHgmWv0C89h/AxnJ7ZtM=",
       "dev": true,
       "license": "MIT",
@@ -1945,14 +1802,12 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
@@ -1962,7 +1817,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/braces/-/braces-3.0.3.tgz",
       "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "dev": true,
       "license": "MIT",
@@ -1975,14 +1829,12 @@
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.28.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.8.tgz",
       "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
@@ -2016,14 +1868,12 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
       "dev": true,
       "license": "MIT",
@@ -2039,7 +1889,6 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha1-iwvuuYYFrfGxKPpDhkA8AJ4CIaU=",
       "dev": true,
       "license": "MIT",
@@ -2049,7 +1898,6 @@
     },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
       "integrity": "sha1-oylHx844mm+hGgmppWPQpFiJU14=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2059,7 +1907,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
       "license": "MIT",
       "dependencies": {
@@ -2077,7 +1924,6 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "license": "MIT",
       "dependencies": {
@@ -2090,7 +1936,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
       "license": "MIT",
       "dependencies": {
@@ -2106,7 +1951,6 @@
     },
     "node_modules/camel-case": {
       "version": "4.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha1-lygHKpVPgFIoIlpt7qazhGHhvVo=",
       "dev": true,
       "license": "MIT",
@@ -2117,7 +1961,6 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
       "dev": true,
       "license": "MIT",
@@ -2130,7 +1973,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001809",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
       "integrity": "sha1-5s9x8U3f4AjxFN0qhGkjvjwDoHs=",
       "dev": true,
       "funding": [
@@ -2151,7 +1993,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "dev": true,
       "license": "MIT",
@@ -2168,7 +2009,6 @@
     },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
       "license": "MIT",
@@ -2181,7 +2021,6 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha1-e+N6TAPJruHs/oYqSiOyxwwgXTA=",
       "dev": true,
       "license": "MIT",
@@ -2197,7 +2036,6 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha1-Bb/9f/koRlCTMUcIyTvfqb0fD1s=",
       "dev": true,
       "license": "MIT",
@@ -2207,7 +2045,6 @@
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clean-css/-/clean-css-5.3.3.tgz",
       "integrity": "sha1-szBlPNO9a3UAnMJccUyue5M1HM0=",
       "dev": true,
       "license": "MIT",
@@ -2220,7 +2057,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
@@ -2235,7 +2071,6 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -2245,14 +2080,12 @@
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
@@ -2267,7 +2100,6 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -2280,7 +2112,6 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "license": "MIT",
@@ -2298,7 +2129,6 @@
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
       "dev": true,
       "license": "MIT",
@@ -2313,7 +2143,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dev": true,
       "license": "MIT",
@@ -2326,14 +2155,12 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "8.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-8.3.0.tgz",
       "integrity": "sha1-SDfqGy2me5xhamevuw+v7lZ7ymY=",
       "dev": true,
       "license": "MIT",
@@ -2343,7 +2170,6 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
       "dev": true,
       "license": "MIT",
@@ -2356,7 +2182,6 @@
     },
     "node_modules/compression": {
       "version": "1.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/compression/-/compression-1.8.1.tgz",
       "integrity": "sha1-SkXZCawWUJGVqaKL2RCUiJwYDXk=",
       "dev": true,
       "license": "MIT",
@@ -2375,7 +2200,6 @@
     },
     "node_modules/compression/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "license": "MIT",
@@ -2385,14 +2209,12 @@
     },
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
       "integrity": "sha1-ZHJkhFJRoNryW5fOh4NMrOD18cg=",
       "dev": true,
       "license": "MIT",
@@ -2402,7 +2224,6 @@
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha1-89t4nHUtRVZMx+nh4LMXkNSjjhc=",
       "dev": true,
       "license": "MIT",
@@ -2416,7 +2237,6 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha1-i3cxYmVtHRCGeEyPI6VM5tc9eRg=",
       "dev": true,
       "license": "MIT",
@@ -2426,7 +2246,6 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha1-VWNpxHKiupEPKXmJG1JrNDYjftc=",
       "dev": true,
       "license": "MIT",
@@ -2436,7 +2255,6 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha1-V8f8PMKTrKuf7FTXPhVpDr5KF5M=",
       "dev": true,
       "license": "MIT",
@@ -2446,14 +2264,12 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha1-wdfo8eX2z8n/ZfnNNS03NIdWwzM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "dev": true,
       "license": "MIT",
@@ -2468,7 +2284,6 @@
     },
     "node_modules/css-loader": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-loader/-/css-loader-7.1.4.tgz",
       "integrity": "sha1-j2v5+PyMvvfS726ArMZUXq76kLE=",
       "dev": true,
       "license": "MIT",
@@ -2504,7 +2319,6 @@
     },
     "node_modules/css-select": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-select/-/css-select-4.3.0.tgz",
       "integrity": "sha1-23EpsoRmYv2GKM/ElquytZ5BUps=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2521,7 +2335,6 @@
     },
     "node_modules/css-what": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha1-zcyPm2l3cZ/fvR3nrsJKv3Vrneo=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2534,7 +2347,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
       "dev": true,
       "license": "MIT",
@@ -2547,14 +2359,12 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha1-IRoDupXsr3eYqMcZjXlTYhH4hXA=",
       "license": "MIT",
       "dependencies": {
@@ -2571,7 +2381,6 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha1-noD3ylJFPOPpPSWjUxh2fqdwRzU=",
       "license": "MIT",
       "dependencies": {
@@ -2588,7 +2397,6 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha1-BoMH+bcat2274QKROJ4CCFZgYZE=",
       "license": "MIT",
       "dependencies": {
@@ -2605,7 +2413,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
@@ -2623,7 +2430,6 @@
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
       "dev": true,
       "license": "MIT",
@@ -2636,7 +2442,6 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/default-browser/-/default-browser-5.5.0.tgz",
       "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
       "dev": true,
       "license": "MIT",
@@ -2653,7 +2458,6 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha1-96fMuPUQS/jg9xujscz6Xq/bIeg=",
       "dev": true,
       "license": "MIT",
@@ -2666,7 +2470,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
       "license": "MIT",
       "dependencies": {
@@ -2683,7 +2486,6 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
       "dev": true,
       "license": "MIT",
@@ -2696,7 +2498,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=",
       "license": "MIT",
       "dependencies": {
@@ -2713,7 +2514,6 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/depd/-/depd-2.0.0.tgz",
       "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
       "dev": true,
       "license": "MIT",
@@ -2723,7 +2523,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
       "dev": true,
       "license": "Apache-2.0",
@@ -2734,7 +2533,6 @@
     },
     "node_modules/diff": {
       "version": "8.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/diff/-/diff-8.0.4.tgz",
       "integrity": "sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2744,7 +2542,6 @@
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dns-packet/-/dns-packet-5.6.1.tgz",
       "integrity": "sha1-roiK1CWp0UeKBnQlarhm3hASzy8=",
       "dev": true,
       "license": "MIT",
@@ -2757,7 +2554,6 @@
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-converter/-/dom-converter-0.2.0.tgz",
       "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
       "dev": true,
       "license": "MIT",
@@ -2767,7 +2563,6 @@
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha1-3l1Bsa6ikCFdxFptrorc8dMuLTA=",
       "dev": true,
       "license": "MIT",
@@ -2782,7 +2577,6 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0=",
       "dev": true,
       "funding": [
@@ -2795,7 +2589,6 @@
     },
     "node_modules/domhandler": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha1-jXkgM0FvWdaLwDpap7AYwcqJJ5w=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2811,7 +2604,6 @@
     },
     "node_modules/domutils": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha1-RDfe9dtuLR9dbuhZvZXKfQIEgTU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2826,7 +2618,6 @@
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha1-mytnDQCkMWZ6inW6Kc0bmICc51E=",
       "dev": true,
       "license": "MIT",
@@ -2837,7 +2628,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
       "license": "MIT",
       "dependencies": {
@@ -2851,35 +2641,30 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.403",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
       "integrity": "sha1-im5CK8aMXS+k2MX6K6mlg8PURSw=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
       "dev": true,
       "license": "MIT",
@@ -2889,7 +2674,6 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
       "integrity": "sha1-tNrTJVt1RfB7pVNRiYaOn4X0dXM=",
       "dev": true,
       "license": "MIT",
@@ -2903,7 +2687,6 @@
     },
     "node_modules/entities": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-2.2.0.tgz",
       "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2913,7 +2696,6 @@
     },
     "node_modules/envinfo": {
       "version": "7.21.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/envinfo/-/envinfo-7.21.0.tgz",
       "integrity": "sha1-BKJRvnn5JUhUHzfRPItvIpQMO64=",
       "dev": true,
       "license": "MIT",
@@ -2926,7 +2708,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-abstract/-/es-abstract-1.24.2.tgz",
       "integrity": "sha1-Lb04wYBzXumD93WFFAonBqlj7Zo=",
       "license": "MIT",
       "dependencies": {
@@ -2994,7 +2775,6 @@
     },
     "node_modules/es-abstract-get": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
       "integrity": "sha1-Hq6HEB9Cvt62p0DoxQUSca74kIg=",
       "license": "MIT",
       "dependencies": {
@@ -3012,7 +2792,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "license": "MIT",
       "engines": {
@@ -3021,7 +2800,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "license": "MIT",
       "engines": {
@@ -3030,14 +2808,12 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha1-W/LfBpmdu+XwBqX0ahH7n1t7ORs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "license": "MIT",
       "dependencies": {
@@ -3049,7 +2825,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
       "license": "MIT",
       "dependencies": {
@@ -3064,7 +2839,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
       "integrity": "sha1-DIVCkc8Ne0Oda55XceqDf/rx+ZE=",
       "license": "MIT",
       "dependencies": {
@@ -3084,19 +2858,16 @@
     },
     "node_modules/es6-object-assign": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "license": "MIT"
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
       "license": "MIT"
     },
     "node_modules/es6-string-polyfills": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es6-string-polyfills/-/es6-string-polyfills-1.0.0.tgz",
       "integrity": "sha1-AKiHjwXpzN+qiYdX5WPFd4TG/NE=",
       "license": "MIT",
       "dependencies": {
@@ -3110,7 +2881,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -3120,14 +2890,12 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "dev": true,
       "license": "MIT",
@@ -3140,7 +2908,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3154,7 +2921,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3167,7 +2933,6 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3177,7 +2942,6 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3187,7 +2951,6 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true,
       "license": "MIT",
@@ -3197,7 +2960,6 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/events/-/events-3.3.0.tgz",
       "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
       "dev": true,
       "license": "MIT",
@@ -3207,7 +2969,6 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express/-/express-5.2.1.tgz",
       "integrity": "sha1-jyHRW20yf5K0eU7PjLCKcvlWrAQ=",
       "dev": true,
       "license": "MIT",
@@ -3251,14 +3012,12 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
       "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
       "dev": true,
       "funding": [
@@ -3275,7 +3034,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -3293,7 +3051,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "dev": true,
       "license": "MIT",
@@ -3306,7 +3063,6 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha1-osUXplWYUrzbBtH4vX9Rto+tgJk=",
       "dev": true,
       "license": "MIT",
@@ -3328,7 +3084,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
       "dev": true,
       "license": "MIT",
@@ -3345,7 +3100,6 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/flat/-/flat-5.0.2.tgz",
       "integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3355,7 +3109,6 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha1-1lBogCeCaSD+6wr3R+57lCGkHUc=",
       "license": "MIT",
       "dependencies": {
@@ -3370,7 +3123,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
       "dev": true,
       "license": "ISC",
@@ -3387,7 +3139,6 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
       "dev": true,
       "license": "MIT",
@@ -3397,7 +3148,6 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha1-jdffahs6Gzpc8YbAWl3SZ2ImNaQ=",
       "dev": true,
       "license": "MIT",
@@ -3407,7 +3157,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "license": "MIT",
       "funding": {
@@ -3416,7 +3165,6 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
       "integrity": "sha1-dY8+hPpUJnJFS9XhTLCBpc4H9ww=",
       "license": "MIT",
       "dependencies": {
@@ -3439,7 +3187,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
       "license": "MIT",
       "funding": {
@@ -3448,7 +3195,6 @@
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha1-DnXdQQ0SQ2h6C6LpUblO7bj3N6I=",
       "license": "MIT",
       "engines": {
@@ -3457,7 +3203,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "license": "ISC",
@@ -3467,7 +3212,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "license": "MIT",
       "dependencies": {
@@ -3491,7 +3235,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
       "license": "MIT",
       "dependencies": {
@@ -3504,7 +3247,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha1-e91U4L7+j/yfO04gMiDZ8eiBtu4=",
       "license": "MIT",
       "dependencies": {
@@ -3521,7 +3263,6 @@
     },
     "node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-10.5.0.tgz",
       "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -3543,7 +3284,6 @@
     },
     "node_modules/glob-to-regex.js": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
       "integrity": "sha1-KzI3KCcdEzgwhQ4yMR9AdmxfZBM=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3560,7 +3300,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha1-dDDtOpddl7+1m8zkH1yruvplEjY=",
       "license": "MIT",
       "dependencies": {
@@ -3576,7 +3315,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "license": "MIT",
       "engines": {
@@ -3588,14 +3326,12 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha1-KGB+llrJZ+A80qLHCiY2oe2tSf4=",
       "license": "MIT",
       "engines": {
@@ -3607,7 +3343,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true,
       "license": "MIT",
@@ -3617,7 +3352,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
       "license": "MIT",
       "dependencies": {
@@ -3629,7 +3363,6 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha1-XeWm6r2V/f/ZgYtDBV6AZeOf6dU=",
       "license": "MIT",
       "dependencies": {
@@ -3644,7 +3377,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "license": "MIT",
       "engines": {
@@ -3656,7 +3388,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
       "license": "MIT",
       "dependencies": {
@@ -3671,7 +3402,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
@@ -3683,7 +3413,6 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true,
       "license": "MIT",
@@ -3693,7 +3422,6 @@
     },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
       "integrity": "sha1-v8gYk0zAeRj2s2afV3Ts39SPMqs=",
       "dev": true,
       "license": "MIT",
@@ -3715,7 +3443,6 @@
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.6.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-webpack-plugin/-/html-webpack-plugin-5.6.8.tgz",
       "integrity": "sha1-VCXbxj61M/+lnpI0K+lIlKEl/CM=",
       "dev": true,
       "license": "MIT",
@@ -3748,7 +3475,6 @@
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/htmlparser2/-/htmlparser2-6.1.0.tgz",
       "integrity": "sha1-xNditsM3GgXb5l6UrkOp+EX7j7c=",
       "dev": true,
       "funding": [
@@ -3768,7 +3494,6 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha1-NtL2W8kJyHkAGN02+02T2myq4Gs=",
       "dev": true,
       "license": "MIT",
@@ -3789,7 +3514,6 @@
     },
     "node_modules/http-proxy-middleware": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-proxy-middleware/-/http-proxy-middleware-4.2.0.tgz",
       "integrity": "sha1-8HkPw06zxCrrTpCEFLxFTcaqJ00=",
       "dev": true,
       "license": "MIT",
@@ -3806,14 +3530,12 @@
     },
     "node_modules/httpxy": {
       "version": "0.5.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/httpxy/-/httpxy-0.5.5.tgz",
       "integrity": "sha1-JQNjFjzJWFjcNiM7sIv5yYpV+ro=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
       "integrity": "sha1-WWaNMjrakiKNKoadPkdNWjO2nms=",
       "dev": true,
       "license": "MIT",
@@ -3823,7 +3545,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
       "dev": true,
       "license": "MIT",
@@ -3840,7 +3561,6 @@
     },
     "node_modules/icss-utils": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha1-xr5oWKvQE9do6YNmrkfiXViHsa4=",
       "dev": true,
       "license": "ISC",
@@ -3853,14 +3573,12 @@
     },
     "node_modules/immutable": {
       "version": "5.1.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/immutable/-/immutable-5.1.9.tgz",
       "integrity": "sha1-rCPDoBmSq2ZeFKyf//KY8ozXSgw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha1-w9XHRXmMAqb4uJdyarpRABhu4mA=",
       "dev": true,
       "license": "MIT",
@@ -3880,14 +3598,12 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha1-HqyRdilH0vcFa8g42T4TsulgSWE=",
       "license": "MIT",
       "dependencies": {
@@ -3901,7 +3617,6 @@
     },
     "node_modules/interpret": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/interpret/-/interpret-3.1.1.tgz",
       "integrity": "sha1-W+DO7WfKecbEvFzw1+6EPc6hEMQ=",
       "dev": true,
       "license": "MIT",
@@ -3911,14 +3626,12 @@
     },
     "node_modules/intersection-observer": {
       "version": "0.5.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/intersection-observer/-/intersection-observer-0.5.1.tgz",
       "integrity": "sha1-40D8Vs50KQ/isjlNHOiMQ1Osbfo=",
       "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
       "license": "W3C-20150513"
     },
     "node_modules/ipaddr.js": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
       "integrity": "sha1-fUtsOfk5L7Yc+AfebkJeIsEOBh8=",
       "dev": true,
       "license": "MIT",
@@ -3928,7 +3641,6 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha1-ZXQuHmh70sxmYlMGj9hwf+TUQoA=",
       "license": "MIT",
       "dependencies": {
@@ -3945,7 +3657,6 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha1-PmkBjI4E5ztzh5PQIL/ohLn9NSM=",
       "license": "MIT",
       "dependencies": {
@@ -3964,7 +3675,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha1-3aejRF31ekJYPbQihoLrp8QXBnI=",
       "license": "MIT",
       "dependencies": {
@@ -3979,7 +3689,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha1-cGf0dwmAmjk8cf9bs+E12KkhXZ4=",
       "license": "MIT",
       "dependencies": {
@@ -3995,7 +3704,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU=",
       "license": "MIT",
       "engines": {
@@ -4007,7 +3715,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha1-PgdFCoCA684/vwysSU9NKrMk4II=",
       "dev": true,
       "license": "MIT",
@@ -4023,7 +3730,6 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha1-uuCkG5aImGwhiN2mZX5WuPnmO44=",
       "license": "MIT",
       "dependencies": {
@@ -4040,7 +3746,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha1-rYVUGZb8eqiycpcB0ntzGfldgvc=",
       "license": "MIT",
       "dependencies": {
@@ -4056,7 +3761,6 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
       "dev": true,
       "license": "MIT",
@@ -4072,7 +3776,6 @@
     },
     "node_modules/is-document.all": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-document.all/-/is-document.all-1.0.0.tgz",
       "integrity": "sha1-FjpL+zYsbtexGM5GzezE433uMZU=",
       "license": "MIT",
       "dependencies": {
@@ -4087,7 +3790,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "license": "MIT",
@@ -4097,7 +3799,6 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha1-7v3NxslN3QZ02chYh7+T+USpfJA=",
       "license": "MIT",
       "dependencies": {
@@ -4112,7 +3813,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true,
       "license": "MIT",
@@ -4122,7 +3822,6 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha1-rjth49XqTkg5uQutIrAjNQUaF9U=",
       "license": "MIT",
       "dependencies": {
@@ -4141,7 +3840,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
       "license": "MIT",
@@ -4154,7 +3852,6 @@
     },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
       "integrity": "sha1-jrc8HKu6d3SNOJWI7uoTKmMFdiI=",
       "dev": true,
       "license": "MIT",
@@ -4167,7 +3864,6 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
       "dev": true,
       "license": "MIT",
@@ -4186,7 +3882,6 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha1-7elrf+HicLPERl46RlZYdkkm1i4=",
       "license": "MIT",
       "engines": {
@@ -4198,7 +3893,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
       "license": "MIT",
       "engines": {
@@ -4210,7 +3904,6 @@
     },
     "node_modules/is-network-error": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-network-error/-/is-network-error-1.3.2.tgz",
       "integrity": "sha1-lGC8MPhBmkvKdxFPTeiKPuXgxRk=",
       "dev": true,
       "license": "MIT",
@@ -4223,7 +3916,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true,
       "license": "MIT",
@@ -4233,7 +3925,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha1-FEsh6VobwUggXcwoFKkTTsQbJUE=",
       "license": "MIT",
       "dependencies": {
@@ -4249,7 +3940,6 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
       "dev": true,
       "license": "MIT",
@@ -4259,7 +3949,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha1-1lAl7ew2V84DL9fbY8l4g+rtcfA=",
       "dev": true,
       "license": "MIT",
@@ -4272,7 +3961,6 @@
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "license": "MIT",
@@ -4285,14 +3973,12 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha1-Qv+fhCBsGZHSbev1IN1cAQQt0vM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha1-dtcKPtEO+b5I61d4h9dCBb8MrSI=",
       "license": "MIT",
       "dependencies": {
@@ -4310,7 +3996,6 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha1-irIJ6kJGCBQTct7W4MsgDvHZ0B0=",
       "license": "MIT",
       "engines": {
@@ -4322,7 +4007,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha1-m2eES9m38ka6BwjDqT40Jpx3T28=",
       "license": "MIT",
       "dependencies": {
@@ -4337,7 +4021,6 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha1-kuo/PVxbbgOcqGd+WsjQfqdzy7k=",
       "license": "MIT",
       "dependencies": {
@@ -4353,7 +4036,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha1-9HdhJ59TLisFpwJKdQbbvtrNBjQ=",
       "license": "MIT",
       "dependencies": {
@@ -4370,7 +4052,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha1-S/tKRbYc7oOlpG+6d45OjVnAzgs=",
       "license": "MIT",
       "dependencies": {
@@ -4385,7 +4066,6 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
       "dev": true,
       "license": "MIT",
@@ -4398,7 +4078,6 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha1-v3JhXWSd/l9pkHnFS4PkfRrhnP0=",
       "license": "MIT",
       "engines": {
@@ -4410,7 +4089,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha1-7qQwGCvo1kF0vZa/+8RvIb8/kpM=",
       "license": "MIT",
       "dependencies": {
@@ -4425,7 +4103,6 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha1-yfXesLwZBsbW8QJ/KE3fRZJJ2so=",
       "license": "MIT",
       "dependencies": {
@@ -4441,7 +4118,6 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
       "dev": true,
       "license": "MIT",
@@ -4457,20 +4133,17 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true,
       "license": "MIT",
@@ -4480,7 +4153,6 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -4496,7 +4168,6 @@
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha1-jRRvCQDolzsQa29zzB6ajLhvjbA=",
       "dev": true,
       "license": "MIT",
@@ -4511,13 +4182,11 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "dev": true,
       "funding": [
@@ -4540,14 +4209,12 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true,
       "license": "MIT",
@@ -4557,7 +4224,6 @@
     },
     "node_modules/launch-editor": {
       "version": "2.14.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/launch-editor/-/launch-editor-2.14.1.tgz",
       "integrity": "sha1-9+DaP1iq6gP+oBB02EC19zntfdw=",
       "dev": true,
       "license": "MIT",
@@ -4568,7 +4234,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
       "dev": true,
       "license": "MIT",
@@ -4584,14 +4249,12 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
       "dev": true,
       "license": "MIT",
@@ -4608,7 +4271,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "license": "MIT",
       "dependencies": {
@@ -4620,7 +4282,6 @@
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha1-b6I3xj29xKgsoP2ILkci3F5jTig=",
       "dev": true,
       "license": "MIT",
@@ -4630,21 +4291,18 @@
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
       "license": "MIT",
       "engines": {
@@ -4653,7 +4311,6 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/media-typer/-/media-typer-1.1.1.tgz",
       "integrity": "sha1-bwNUAN/jq51WB7x3VGzjDML5xrg=",
       "dev": true,
       "license": "MIT",
@@ -4667,7 +4324,6 @@
     },
     "node_modules/memfs": {
       "version": "4.68.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/memfs/-/memfs-4.68.1.tgz",
       "integrity": "sha1-5C+mnIczBanNCyio0jC5bvrNi10=",
       "dev": true,
       "license": "Apache-2.0",
@@ -4694,7 +4350,6 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha1-6pIvZgY1oiSe5WXgRJ+VHmtgOAg=",
       "dev": true,
       "license": "MIT",
@@ -4707,14 +4362,12 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "dev": true,
       "license": "MIT",
@@ -4728,7 +4381,6 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "dev": true,
       "license": "MIT",
@@ -4741,7 +4393,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
       "dev": true,
       "license": "MIT",
@@ -4751,7 +4402,6 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
       "dev": true,
       "license": "MIT",
@@ -4768,7 +4418,6 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "dev": true,
       "license": "ISC",
@@ -4784,7 +4433,6 @@
     },
     "node_modules/minimizer-webpack-plugin": {
       "version": "5.6.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
       "integrity": "sha1-KJkipMlsTtHdt2uKAL2AdOiaL38=",
       "dev": true,
       "license": "MIT",
@@ -4845,7 +4493,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -4855,7 +4502,6 @@
     },
     "node_modules/mocha": {
       "version": "11.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mocha/-/mocha-11.8.0.tgz",
       "integrity": "sha1-kWPMWWAOwmRw9rBA4wqlGsyXPtI=",
       "dev": true,
       "license": "MIT",
@@ -4892,14 +4538,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/multicast-dns/-/multicast-dns-7.2.5.tgz",
       "integrity": "sha1-d+tGBX9NetvRbZKQ+nKZ9vpkzO0=",
       "dev": true,
       "license": "MIT",
@@ -4913,7 +4557,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.18.tgz",
       "integrity": "sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=",
       "dev": true,
       "funding": [
@@ -4932,7 +4575,6 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha1-d3lI4kUmUcVwtxLdAcI+JicT//c=",
       "dev": true,
       "license": "MIT",
@@ -4942,14 +4584,12 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/no-case": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha1-02H9XJgA9VhVGoNp/A3NRmK2Ek0=",
       "dev": true,
       "license": "MIT",
@@ -4960,7 +4600,6 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha1-Grpmk7DyVSWKBJ1iEykykyKq1Vg=",
       "dev": true,
       "license": "MIT",
@@ -4968,7 +4607,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.53",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.53.tgz",
       "integrity": "sha1-D+Wtink14HUXL1dOVvDCDwf6Qa8=",
       "dev": true,
       "license": "MIT",
@@ -4978,7 +4616,6 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha1-yeq0KO/842zWuSySS9sADvHx7R0=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4991,7 +4628,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "license": "MIT",
       "engines": {
@@ -5000,7 +4636,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
       "license": "MIT",
       "engines": {
@@ -5012,7 +4647,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "license": "MIT",
       "engines": {
@@ -5021,7 +4655,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha1-jBTKGkJMalYbC7KiL2b1BJqUXT0=",
       "license": "MIT",
       "dependencies": {
@@ -5041,7 +4674,6 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
       "dev": true,
       "license": "MIT",
@@ -5054,7 +4686,6 @@
     },
     "node_modules/on-headers": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/on-headers/-/on-headers-1.1.0.tgz",
       "integrity": "sha1-WdpPkcRfX5icbkvO3Fo7Cu1w/2U=",
       "dev": true,
       "license": "MIT",
@@ -5064,7 +4695,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "license": "ISC",
@@ -5074,7 +4704,6 @@
     },
     "node_modules/open": {
       "version": "11.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/open/-/open-11.0.0.tgz",
       "integrity": "sha1-iX5hMvmU01VMvPcuDfmPF2p+X2I=",
       "dev": true,
       "license": "MIT",
@@ -5095,7 +4724,6 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/own-keys/-/own-keys-1.0.2.tgz",
       "integrity": "sha1-MUSOwfeB7LFEf29qoNZTQiKvWd4=",
       "license": "MIT",
       "dependencies": {
@@ -5113,7 +4741,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
       "dev": true,
       "license": "MIT",
@@ -5129,7 +4756,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
       "dev": true,
       "license": "MIT",
@@ -5145,7 +4771,6 @@
     },
     "node_modules/p-retry": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-retry/-/p-retry-8.0.0.tgz",
       "integrity": "sha1-FQX68UlCMm4Y1AkfXWBbrmVjTns=",
       "dev": true,
       "license": "MIT",
@@ -5161,7 +4786,6 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "license": "MIT",
@@ -5171,14 +4795,12 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha1-fRf+SqEr3jTUp32RrPtiGcqtAcU=",
       "dev": true,
       "license": "MIT",
@@ -5189,7 +4811,6 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
       "dev": true,
       "license": "MIT",
@@ -5199,7 +4820,6 @@
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha1-tI4O8rmOIF58Ha50fQsVCCN2YOs=",
       "dev": true,
       "license": "MIT",
@@ -5210,7 +4830,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true,
       "license": "MIT",
@@ -5220,7 +4839,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true,
       "license": "MIT",
@@ -5230,14 +4848,12 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5254,7 +4870,6 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha1-eVxCDE98pFxbiHNm9iLuDJhSzM0=",
       "dev": true,
       "license": "MIT",
@@ -5265,14 +4880,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
@@ -5285,7 +4898,6 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "license": "MIT",
@@ -5298,7 +4910,6 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "license": "MIT",
@@ -5312,7 +4923,6 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "license": "MIT",
@@ -5325,7 +4935,6 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "license": "MIT",
@@ -5341,7 +4950,6 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "license": "MIT",
@@ -5354,7 +4962,6 @@
     },
     "node_modules/pkijs": {
       "version": "3.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkijs/-/pkijs-3.4.0.tgz",
       "integrity": "sha1-2RZN7zD/bZe+LYiWbV42GSSZypw=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -5372,14 +4979,12 @@
     },
     "node_modules/pkijs/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha1-k+NYK8DlQmWG2dB7ee5A/IQd5K4=",
       "license": "MIT",
       "engines": {
@@ -5388,7 +4993,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.26",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.26.tgz",
       "integrity": "sha1-bnUTV4DH4Q3zQzvyJmxVLTXIxiA=",
       "dev": true,
       "funding": [
@@ -5417,7 +5021,6 @@
     },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
       "integrity": "sha1-tEl8uFqcDEtaq+t1m7JejYnxUAI=",
       "dev": true,
       "license": "ISC",
@@ -5430,7 +5033,6 @@
     },
     "node_modules/postcss-modules-local-by-default": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
       "integrity": "sha1-0VD0ODeDHa4l5AhVluhPb11uw2g=",
       "dev": true,
       "license": "MIT",
@@ -5448,7 +5050,6 @@
     },
     "node_modules/postcss-modules-scope": {
       "version": "3.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
       "integrity": "sha1-G7zN3LOY8delEeCi0dBHcYr0B4w=",
       "dev": true,
       "license": "ISC",
@@ -5464,7 +5065,6 @@
     },
     "node_modules/postcss-modules-values": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
       "integrity": "sha1-18Xn5ow7s8myfL9Iyguz/7RgLJw=",
       "dev": true,
       "license": "ISC",
@@ -5480,7 +5080,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
       "integrity": "sha1-7nsJByTrYHObUwZg5bQCIA5pSpc=",
       "dev": true,
       "license": "MIT",
@@ -5494,14 +5093,12 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha1-cjwJkgg2um0+WvAZ+SvAlxwC5RQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/powershell-utils/-/powershell-utils-0.1.0.tgz",
       "integrity": "sha1-WkLJqCT7Ty8lHMtBqq5zMU9dasI=",
       "dev": true,
       "license": "MIT",
@@ -5514,7 +5111,6 @@
     },
     "node_modules/pretty-error": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pretty-error/-/pretty-error-4.0.0.tgz",
       "integrity": "sha1-kKcD9G3XI0rbRtD4SCPp0cuPENY=",
       "dev": true,
       "license": "MIT",
@@ -5525,7 +5121,6 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
       "license": "MIT",
       "dependencies": {
@@ -5536,7 +5131,6 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
       "dev": true,
       "license": "MIT",
@@ -5550,7 +5144,6 @@
     },
     "node_modules/proxy-addr/node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
       "dev": true,
       "license": "MIT",
@@ -5560,7 +5153,6 @@
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha1-7EbjTbdCK55P3FSQV4wYg2V9YAE=",
       "dev": true,
       "license": "MIT",
@@ -5570,14 +5162,12 @@
     },
     "node_modules/pvtsutils/node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/pvutils": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pvutils/-/pvutils-1.2.0.tgz",
       "integrity": "sha1-S1SHqczNUtJ1sFOHdXkKPKmCvCI=",
       "dev": true,
       "license": "MIT",
@@ -5587,7 +5177,6 @@
     },
     "node_modules/qs": {
       "version": "6.15.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/qs/-/qs-6.15.3.tgz",
       "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -5604,13 +5193,11 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y=",
       "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha1-1/Gb6BK7YnIUcrRdO+IZ7wlXK0c=",
       "dev": true,
       "license": "MIT",
@@ -5624,7 +5211,6 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha1-PjraWuVWj5CV2EN2/TpJuPsAClE=",
       "dev": true,
       "license": "MIT",
@@ -5640,7 +5226,6 @@
     },
     "node_modules/react": {
       "version": "16.13.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react/-/react-16.13.1.tgz",
       "integrity": "sha1-LoGIIvGpdDEiwGPWQQ2FweOv5I4=",
       "license": "MIT",
       "dependencies": {
@@ -5654,7 +5239,6 @@
     },
     "node_modules/react-dom": {
       "version": "16.13.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-dom/-/react-dom-16.13.1.tgz",
       "integrity": "sha1-wb03MxoEhsB47lTEdAcgmTsuDn8=",
       "license": "MIT",
       "dependencies": {
@@ -5669,13 +5253,11 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
       "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha1-64WAFDX78qfuWPGeCSGwaPxplI0=",
       "dev": true,
       "license": "MIT",
@@ -5689,7 +5271,6 @@
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rechoir/-/rechoir-0.8.0.tgz",
       "integrity": "sha1-Sfhm4NMhRhQto62PDv81KzIV/yI=",
       "dev": true,
       "license": "MIT",
@@ -5702,14 +5283,12 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha1-QAyEW2y6h6IfLGXErrFY9PpNnFs=",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha1-xikhnnijMW2LYEx2XvaJlpZOe/k=",
       "license": "MIT",
       "dependencies": {
@@ -5731,7 +5310,6 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha1-GtbGLUSiWQB+VbOXDgD3Ru+8qhk=",
       "license": "MIT",
       "dependencies": {
@@ -5751,7 +5329,6 @@
     },
     "node_modules/relateurl": {
       "version": "0.2.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true,
       "license": "MIT",
@@ -5761,7 +5338,6 @@
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/renderkid/-/renderkid-3.0.0.tgz",
       "integrity": "sha1-X9gj5NaVHTc1jsyaWLHwaDa2Joo=",
       "dev": true,
       "license": "MIT",
@@ -5775,7 +5351,6 @@
     },
     "node_modules/renderkid/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -5785,7 +5360,6 @@
     },
     "node_modules/renderkid/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -5798,7 +5372,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "license": "MIT",
@@ -5808,7 +5381,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
       "dev": true,
       "license": "MIT",
@@ -5818,13 +5390,11 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha1-9bKmgIl8acI4oTzRaxVnH4tzVJ8=",
       "dev": true,
       "license": "MIT",
@@ -5846,7 +5416,6 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
       "dev": true,
       "license": "MIT",
@@ -5859,7 +5428,6 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
       "dev": true,
       "license": "MIT",
@@ -5869,7 +5437,6 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/router/-/router-2.2.0.tgz",
       "integrity": "sha1-AZvmILcRyHZBFnzHm5kJDwCxRu8=",
       "dev": true,
       "license": "MIT",
@@ -5886,7 +5453,6 @@
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha1-Lp5UxGZOwxBsW1Yw4knT1llcSRE=",
       "dev": true,
       "license": "MIT",
@@ -5899,7 +5465,6 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
       "integrity": "sha1-pUzJthpX8ztCq608vdo6KzjMVxk=",
       "license": "MIT",
       "dependencies": {
@@ -5918,7 +5483,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
       "dev": true,
       "funding": [
@@ -5939,7 +5503,6 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha1-AYUOmBwWAtOYyFCB82Dk5tA9J/U=",
       "license": "MIT",
       "dependencies": {
@@ -5955,7 +5518,6 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha1-f4fftnoxUHguqvGFg/9dFxGsEME=",
       "license": "MIT",
       "dependencies": {
@@ -5972,14 +5534,12 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
       "version": "1.102.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass/-/sass-1.102.0.tgz",
       "integrity": "sha1-Ttk3jzfKQYanbW0fUqZoDJK2vYA=",
       "dev": true,
       "license": "MIT",
@@ -6000,7 +5560,6 @@
     },
     "node_modules/sass-loader": {
       "version": "17.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-loader/-/sass-loader-17.0.0.tgz",
       "integrity": "sha1-j0+IZNg0wauxjw89K8ZTu/Kd3io=",
       "dev": true,
       "license": "MIT",
@@ -6034,7 +5593,6 @@
     },
     "node_modules/sass/node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha1-lJwSapI4qAeSvpoCZZNPCYrzaaU=",
       "dev": true,
       "license": "MIT",
@@ -6050,7 +5608,6 @@
     },
     "node_modules/sass/node_modules/readdirp": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdirp/-/readdirp-5.1.1.tgz",
       "integrity": "sha1-UgvKBvnRrhuWzAgA2+hLmD0ZQiw=",
       "dev": true,
       "license": "MIT",
@@ -6064,7 +5621,6 @@
     },
     "node_modules/scheduler": {
       "version": "0.19.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha1-Tz4u0sGn1laB9MhU+oxaHMtA8ZY=",
       "license": "MIT",
       "dependencies": {
@@ -6074,7 +5630,6 @@
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha1-WxhQkS+jHfkHFpY9RdkSH9/An0Y=",
       "dev": true,
       "license": "MIT",
@@ -6094,7 +5649,6 @@
     },
     "node_modules/selfsigned": {
       "version": "5.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/selfsigned/-/selfsigned-5.5.0.tgz",
       "integrity": "sha1-TJq3x8nzXxj7apiCwlPrDmvWVXs=",
       "dev": true,
       "license": "MIT",
@@ -6108,7 +5662,6 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -6121,7 +5674,6 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/send/-/send-1.2.1.tgz",
       "integrity": "sha1-nqt0O4dPNVD0CiaGe/KGrWDT8+0=",
       "dev": true,
       "license": "MIT",
@@ -6148,7 +5700,6 @@
     },
     "node_modules/serialize-javascript": {
       "version": "7.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
       "integrity": "sha1-nkYsXG3sXbyLVdkMUqStav+YW58=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6158,7 +5709,6 @@
     },
     "node_modules/serve-index": {
       "version": "1.9.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serve-index/-/serve-index-1.9.2.tgz",
       "integrity": "sha1-KYjjYSEG14peSEnd/1Us5709m8s=",
       "dev": true,
       "license": "MIT",
@@ -6181,7 +5731,6 @@
     },
     "node_modules/serve-index/node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha1-C/C+EltnAUrcsLCSHmLbe//hay4=",
       "dev": true,
       "license": "MIT",
@@ -6195,7 +5744,6 @@
     },
     "node_modules/serve-index/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "license": "MIT",
@@ -6205,7 +5753,6 @@
     },
     "node_modules/serve-index/node_modules/depd": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true,
       "license": "MIT",
@@ -6215,7 +5762,6 @@
     },
     "node_modules/serve-index/node_modules/http-errors": {
       "version": "1.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha1-fD8oV3y8iiBziEVdvWIpXtB71ow=",
       "dev": true,
       "license": "MIT",
@@ -6232,7 +5778,6 @@
     },
     "node_modules/serve-index/node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
       "dev": true,
       "license": "MIT",
@@ -6242,7 +5787,6 @@
     },
     "node_modules/serve-index/node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
       "dev": true,
       "license": "MIT",
@@ -6255,14 +5799,12 @@
     },
     "node_modules/serve-index/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/serve-index/node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha1-WOMjpy/twNb5zU0x/kn1FHlZDM0=",
       "dev": true,
       "license": "MIT",
@@ -6272,7 +5814,6 @@
     },
     "node_modules/serve-index/node_modules/statuses": {
       "version": "1.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true,
       "license": "MIT",
@@ -6282,7 +5823,6 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha1-fxhqSk5fW2Y616QpT/G/N88OmKk=",
       "dev": true,
       "license": "MIT",
@@ -6302,7 +5842,6 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=",
       "license": "MIT",
       "dependencies": {
@@ -6319,7 +5858,6 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
       "license": "MIT",
       "dependencies": {
@@ -6334,7 +5872,6 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha1-B2Dbz/MLLX6AH9bhmYPlbaM3Vl4=",
       "license": "MIT",
       "dependencies": {
@@ -6348,14 +5885,12 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
       "dev": true,
       "license": "MIT",
@@ -6368,7 +5903,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "license": "MIT",
@@ -6381,7 +5915,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true,
       "license": "MIT",
@@ -6391,7 +5924,6 @@
     },
     "node_modules/shell-quote": {
       "version": "1.10.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shell-quote/-/shell-quote-1.10.0.tgz",
       "integrity": "sha1-SCAz4ZLk9cBxUVIf+gNADscbGw8=",
       "dev": true,
       "license": "MIT",
@@ -6404,7 +5936,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
@@ -6423,7 +5954,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
@@ -6439,7 +5969,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
       "license": "MIT",
       "dependencies": {
@@ -6457,7 +5986,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
       "license": "MIT",
       "dependencies": {
@@ -6476,7 +6004,6 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "dev": true,
       "license": "ISC",
@@ -6489,7 +6016,6 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6499,7 +6025,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6509,7 +6034,6 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
       "dev": true,
       "license": "MIT",
@@ -6520,7 +6044,6 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha1-j3XuzvdlteHPzcCA2llAntQk44I=",
       "dev": true,
       "license": "MIT",
@@ -6530,7 +6053,6 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha1-9IH/cKVI9hJNAxLDqhTL+nqlQq0=",
       "license": "MIT",
       "dependencies": {
@@ -6543,7 +6065,6 @@
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
       "dev": true,
       "license": "MIT",
@@ -6562,7 +6083,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
@@ -6577,7 +6097,6 @@
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -6587,14 +6106,12 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -6607,39 +6124,32 @@
     },
     "node_modules/string.fromcodepoint": {
       "version": "0.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
       "integrity": "sha1-jZeDM8C8klOPUPOD5IiPPlYZ1lM="
     },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
       "integrity": "sha1-AErUTIr8cnUnsQjNRitNlxzUabw=",
       "license": "MIT"
     },
     "node_modules/string.prototype.endswith": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
       "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU="
     },
     "node_modules/string.prototype.includes": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.includes/-/string.prototype.includes-1.0.0.tgz",
       "integrity": "sha1-gpNhzvj/uSfe+TzNU3PZ3MN+568=",
       "license": "MIT"
     },
     "node_modules/string.prototype.repeat": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
       "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
     },
     "node_modules/string.prototype.startswith": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
       "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns="
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
       "integrity": "sha1-5r0ZzaOYXQWkLdox89300100MOM=",
       "license": "MIT",
       "dependencies": {
@@ -6661,7 +6171,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
       "integrity": "sha1-vmvPTz/gRgvezNss9PlxsxD4NG4=",
       "license": "MIT",
       "dependencies": {
@@ -6679,7 +6188,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
       "license": "MIT",
       "dependencies": {
@@ -6696,7 +6204,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
       "dev": true,
       "license": "MIT",
@@ -6713,7 +6220,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -6726,7 +6232,6 @@
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -6736,7 +6241,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true,
       "license": "MIT",
@@ -6749,7 +6253,6 @@
     },
     "node_modules/style-loader": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/style-loader/-/style-loader-4.0.0.tgz",
       "integrity": "sha1-DqluRo9DxpYAAR4FicsFxE87F6U=",
       "dev": true,
       "license": "MIT",
@@ -6766,7 +6269,6 @@
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
       "dev": true,
       "license": "MIT",
@@ -6782,7 +6284,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
       "dev": true,
       "license": "MIT",
@@ -6795,7 +6296,6 @@
     },
     "node_modules/tapable": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha1-XafJmSxGA4IhJnmFqyhCGoh58WA=",
       "dev": true,
       "license": "MIT",
@@ -6809,7 +6309,6 @@
     },
     "node_modules/terser": {
       "version": "5.49.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/terser/-/terser-5.49.2.tgz",
       "integrity": "sha1-zAjPtgl+XaZQv9Rcdp69FcUU/CM=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6828,14 +6327,12 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-2.20.3.tgz",
       "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/thingies": {
       "version": "2.6.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/thingies/-/thingies-2.6.1.tgz",
       "integrity": "sha1-TrKOJYWnUojxdloLCPHfoCA1em8=",
       "dev": true,
       "license": "MIT",
@@ -6852,14 +6349,12 @@
     },
     "node_modules/thunky": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -6876,7 +6371,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "license": "MIT",
@@ -6889,7 +6383,6 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha1-O+NDIaiKgg7RvYDfqjPkefu43TU=",
       "dev": true,
       "license": "MIT",
@@ -6899,7 +6392,6 @@
     },
     "node_modules/tree-dump": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tree-dump/-/tree-dump-1.1.0.tgz",
       "integrity": "sha1-qykSkWncRgBEFPWp1KPG6J8T6KQ=",
       "dev": true,
       "license": "Apache-2.0",
@@ -6916,7 +6408,6 @@
     },
     "node_modules/ts-loader": {
       "version": "9.6.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-loader/-/ts-loader-9.6.2.tgz",
       "integrity": "sha1-oI9JNd24ftvVjOM7eyVYwqd/3Uc=",
       "dev": true,
       "license": "MIT",
@@ -6941,7 +6432,6 @@
     },
     "node_modules/ts-loader/node_modules/source-map": {
       "version": "0.7.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha1-o2WKuH5bZCnIofO6AIPUxhyj7wI=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6951,7 +6441,6 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha1-cPAhyeGFvM3Kgg4m3EE4BcEBxx8=",
       "dev": true,
       "license": "MIT",
@@ -6995,13 +6484,11 @@
     },
     "node_modules/tslib": {
       "version": "2.6.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha1-BDj4EK16ntzeeiQcPYDbaTyMv+A=",
       "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tsyringe/-/tsyringe-4.10.0.tgz",
       "integrity": "sha1-0MlYFdWERkIUBgKF6qrdlKoDKZw=",
       "dev": true,
       "license": "MIT",
@@ -7014,14 +6501,12 @@
     },
     "node_modules/tsyringe/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha1-cdGnBTKTWC4WrJ8+uvGrmqSeVXA=",
       "dev": true,
       "license": "MIT",
@@ -7040,7 +6525,6 @@
     },
     "node_modules/type-is/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
       "dev": true,
       "license": "MIT",
@@ -7054,7 +6538,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha1-pyOVRQpIaewDP9VJNxtHrzou5TY=",
       "license": "MIT",
       "dependencies": {
@@ -7068,7 +6551,6 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha1-hAegT314aE89JSqhoUPSt3tBYM4=",
       "license": "MIT",
       "dependencies": {
@@ -7087,7 +6569,6 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha1-rjaYuOyRqKuUUBYQiu8A1b/xI1U=",
       "license": "MIT",
       "dependencies": {
@@ -7108,7 +6589,6 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typed-array-length/-/typed-array-length-1.0.8.tgz",
       "integrity": "sha1-C3Dpgsnp2v4t721kWP9LPy0rbXA=",
       "license": "MIT",
       "dependencies": {
@@ -7128,7 +6608,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -7142,7 +6621,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha1-jZ0snt7qhGDH81AzqIhnlEk00eI=",
       "license": "MIT",
       "dependencies": {
@@ -7160,14 +6638,12 @@
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha1-ROn8nzJEZIzeo15Pm7LWgelBCAk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true,
       "license": "MIT",
@@ -7177,7 +6653,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
       "integrity": "sha1-pxwo3SL1BUgdvEaJCHsY2TPpCv0=",
       "dev": true,
       "funding": [
@@ -7208,7 +6683,6 @@
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha1-nTwvc2wddd070r5QfcwRHx4uqcE=",
       "license": "MIT",
       "dependencies": {
@@ -7218,28 +6692,24 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/utila": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha1-Yzbo1xllyz01obu3hoRFp8BSZL8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true,
       "license": "MIT",
@@ -7249,7 +6719,6 @@
     },
     "node_modules/watchpack": {
       "version": "2.5.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/watchpack/-/watchpack-2.5.2.tgz",
       "integrity": "sha1-4S6C2EZ0Jm/Bxtv+OIkbkv8FIuw=",
       "dev": true,
       "license": "MIT",
@@ -7262,7 +6731,6 @@
     },
     "node_modules/webpack": {
       "version": "5.109.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webpack/-/webpack-5.109.2.tgz",
       "integrity": "sha1-tY3CiVYcMoLbNcIQqZN5qDakwo0=",
       "dev": true,
       "license": "MIT",
@@ -7306,7 +6774,6 @@
     },
     "node_modules/webpack-cli": {
       "version": "7.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webpack-cli/-/webpack-cli-7.2.2.tgz",
       "integrity": "sha1-lP9PiiiqCHyBJ8gh4mpv0KUDI+U=",
       "dev": true,
       "license": "MIT",
@@ -7358,7 +6825,6 @@
     },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "14.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-14.0.3.tgz",
       "integrity": "sha1-Ql15tI+a+C/Nnk/B6or2xewHu8I=",
       "dev": true,
       "license": "MIT",
@@ -7368,7 +6834,6 @@
     },
     "node_modules/webpack-dev-middleware": {
       "version": "8.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webpack-dev-middleware/-/webpack-dev-middleware-8.1.1.tgz",
       "integrity": "sha1-xOcDQJAf9MNJ/UK6oPRwJAGSkfQ=",
       "dev": true,
       "license": "MIT",
@@ -7396,7 +6861,6 @@
     },
     "node_modules/webpack-dev-server": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webpack-dev-server/-/webpack-dev-server-6.0.0.tgz",
       "integrity": "sha1-rzD4DNS8HFssYiTkx5A63NlRTc0=",
       "dev": true,
       "license": "MIT",
@@ -7451,7 +6915,6 @@
     },
     "node_modules/webpack-dev-server/node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha1-lJwSapI4qAeSvpoCZZNPCYrzaaU=",
       "dev": true,
       "license": "MIT",
@@ -7467,7 +6930,6 @@
     },
     "node_modules/webpack-dev-server/node_modules/readdirp": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdirp/-/readdirp-5.1.1.tgz",
       "integrity": "sha1-UgvKBvnRrhuWzAgA2+hLmD0ZQiw=",
       "dev": true,
       "license": "MIT",
@@ -7481,7 +6943,6 @@
     },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webpack-merge/-/webpack-merge-6.0.1.tgz",
       "integrity": "sha1-UMd2ho4IBXRyWrxYab1uTvChbGo=",
       "dev": true,
       "license": "MIT",
@@ -7496,7 +6957,6 @@
     },
     "node_modules/webpack-sources": {
       "version": "3.5.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webpack-sources/-/webpack-sources-3.5.1.tgz",
       "integrity": "sha1-dsJBhIbcwCsqoGlMEEF2woWP6Eo=",
       "dev": true,
       "license": "MIT",
@@ -7506,13 +6966,11 @@
     },
     "node_modules/whatwg-fetch": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-fetch/-/whatwg-fetch-3.0.1.tgz",
       "integrity": "sha1-e8fs5J/Vu1C3UFbfOFeLjyn9UBk=",
       "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "dev": true,
       "license": "ISC",
@@ -7528,7 +6986,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha1-127Cfff6Fl8Y1YCDdKX+I8KbF24=",
       "license": "MIT",
       "dependencies": {
@@ -7547,7 +7004,6 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha1-iRg9obSQerCJprAgKcxdjWV0Jw4=",
       "license": "MIT",
       "dependencies": {
@@ -7574,7 +7030,6 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha1-Yn73YkOSChB+fOjpYZHevksWwqA=",
       "license": "MIT",
       "dependencies": {
@@ -7592,7 +7047,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which-typed-array/-/which-typed-array-1.1.22.tgz",
       "integrity": "sha1-jzzHiu+0C0NzRt1Aodv6XR2kP+k=",
       "license": "MIT",
       "dependencies": {
@@ -7613,21 +7067,18 @@
     },
     "node_modules/wildcard": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha1-WrENAkhxmJVINrY0n3T/+WHhD2c=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workerpool": {
       "version": "9.3.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/workerpool/-/workerpool-9.3.4.tgz",
       "integrity": "sha1-9skjlbIUGv144qiJ6AyzOP6fykE=",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
       "dev": true,
       "license": "MIT",
@@ -7646,7 +7097,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "license": "MIT",
@@ -7664,7 +7114,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -7674,14 +7123,12 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
@@ -7696,7 +7143,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -7709,7 +7155,6 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
       "dev": true,
       "license": "MIT",
@@ -7722,14 +7167,12 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ws/-/ws-8.21.3.tgz",
       "integrity": "sha1-ZgtPrdtqPldchuB4EmkZlh9N5Pw=",
       "dev": true,
       "license": "MIT",
@@ -7751,7 +7194,6 @@
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wsl-utils/-/wsl-utils-0.3.1.tgz",
       "integrity": "sha1-lHmDbd8DviZ6rTq/w8sfbgyfHtE=",
       "dev": true,
       "license": "MIT",
@@ -7768,7 +7210,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
@@ -7778,7 +7219,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "dev": true,
       "license": "MIT",
@@ -7797,7 +7237,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "dev": true,
       "license": "ISC",
@@ -7807,7 +7246,6 @@
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
       "integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
       "dev": true,
       "license": "MIT",
@@ -7823,7 +7261,6 @@
     },
     "node_modules/yargs-unparser/node_modules/is-plain-obj": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
       "dev": true,
       "license": "MIT",
@@ -7833,7 +7270,6 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -7843,14 +7279,12 @@
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
@@ -7865,7 +7299,6 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -7878,7 +7311,6 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yn/-/yn-3.1.1.tgz",
       "integrity": "sha1-HodAGgnXZ8HV6rJqbkwYUYLS61A=",
       "dev": true,
       "license": "MIT",
@@ -7888,7 +7320,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary

The Terraform plan view's lockfile recorded Azure Artifacts proxy URLs in registry dependency `resolved` fields. This change adds `omit-lockfile-registry-resolved=true` to the existing project `.npmrc` and regenerates the lockfile with npm 11.19.0.

The existing `packagefeedproxy.microsoft.io` registry setting remains unchanged. Dependency versions, integrity hashes, and `lockfileVersion` are also unchanged.

## Validation

- `npm config get omit-lockfile-registry-resolved`
- `npm install --package-lock-only --ignore-scripts`
- Repeated lockfile generation and confirmed a clean result
- `npm ci --ignore-scripts`
- `npm test` (22 tests passed)
- `npm run build`

npm config reference: https://docs.npmjs.com/cli/v8/using-npm/config#omit-lockfile-registry-resolved
